### PR TITLE
Support for rate limit responses

### DIFF
--- a/src/Exception/RateLimitException.php
+++ b/src/Exception/RateLimitException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Picqer\BolRetailer\Exception;
+
+class RateLimitException extends HttpException
+{
+}

--- a/src/Offer.php
+++ b/src/Offer.php
@@ -3,6 +3,7 @@ namespace Picqer\BolRetailer;
 
 use GuzzleHttp\Exception\ClientException;
 use Picqer\BolRetailer\Exception\HttpException;
+use Picqer\BolRetailer\Exception\RateLimitException;
 use Picqer\BolRetailer\Exception\OfferNotFoundException;
 
 class Offer extends Model\Offer
@@ -130,6 +131,12 @@ class Offer extends Model\Offer
             throw new OfferNotFoundException(
                 json_decode((string) $response->getBody(), true),
                 404,
+                $e
+            );
+        } elseif ($response && $response->getStatusCode() === 429) {
+            throw new RateLimitException(
+                json_decode((string) $response->getBody(), true),
+                429,
                 $e
             );
         } elseif ($response) {

--- a/src/Order.php
+++ b/src/Order.php
@@ -2,9 +2,10 @@
 namespace Picqer\BolRetailer;
 
 use GuzzleHttp\Exception\ClientException;
-use Picqer\BolRetailer\Exception\HttpException;
-use Picqer\BolRetailer\Exception\OrderNotFoundException;
 use Picqer\BolRetailer\Model;
+use Picqer\BolRetailer\Exception\HttpException;
+use Picqer\BolRetailer\Exception\RateLimitException;
+use Picqer\BolRetailer\Exception\OrderNotFoundException;
 
 class Order extends Model\Order
 {
@@ -61,6 +62,12 @@ class Order extends Model\Order
             throw new OrderNotFoundException(
                 json_decode((string) $response->getBody(), true),
                 404,
+                $e
+            );
+        } elseif ($response && $response->getStatusCode() === 429) {
+            throw new RateLimitException(
+                json_decode((string) $response->getBody(), true),
+                429,
                 $e
             );
         } elseif ($response) {

--- a/src/ProcessStatus.php
+++ b/src/ProcessStatus.php
@@ -3,6 +3,7 @@ namespace Picqer\BolRetailer;
 
 use GuzzleHttp\Exception\ClientException;
 use Picqer\BolRetailer\Exception\HttpException;
+use Picqer\BolRetailer\Exception\RateLimitException;
 use Picqer\BolRetailer\Exception\ProcessStillPendingException;
 use Picqer\BolRetailer\Exception\ProcessStatusNotFoundException;
 
@@ -74,6 +75,12 @@ class ProcessStatus extends Model\ProcessStatus
             throw new ProcessStatusNotFoundException(
                 json_decode((string) $response->getBody(), true),
                 404,
+                $e
+            );
+        } elseif ($response && $response->getStatusCode() === 429) {
+            throw new RateLimitException(
+                json_decode((string) $response->getBody(), true),
+                429,
                 $e
             );
         } elseif ($response) {

--- a/src/Shipment.php
+++ b/src/Shipment.php
@@ -7,6 +7,7 @@ use Picqer\BolRetailer\Model\ReducedOrder;
 use Picqer\BolRetailer\Model\OrderItem;
 use Picqer\BolRetailer\Model\ReducedOrderItem;
 use Picqer\BolRetailer\Exception\HttpException;
+use Picqer\BolRetailer\Exception\RateLimitException;
 use Picqer\BolRetailer\Exception\ShipmentNotFoundException;
 
 class Shipment extends Model\Shipment
@@ -109,6 +110,12 @@ class Shipment extends Model\Shipment
             throw new ShipmentNotFoundException(
                 json_decode((string) $response->getBody(), true),
                 404,
+                $e
+            );
+        } elseif ($response && $response->getStatusCode() === 429) {
+            throw new RateLimitException(
+                json_decode((string) $response->getBody(), true),
+                429,
                 $e
             );
         } elseif ($response) {


### PR DESCRIPTION
This PR adds support for rate limiting. When the client is rate limited by the Bol.com Retailer API, a `Picqer\BolRetailer\Exception\RateLimitException` will be thrown.