### PR TITLE
Implement __isset in the abstract model class

### DIFF
--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -32,6 +32,20 @@ abstract class AbstractModel
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function __isset(string $property)
+    {
+        $getter = sprintf('get%s', ucfirst($property));
+
+        if (method_exists($this, $getter)) {
+            return true;
+        }
+
+        return isset($this->data[$property]);
+    }
+
+    /**
      * Merge the given data into the model.
      *
      * @param array $data The data to merge into the model.

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -39,10 +39,10 @@ abstract class AbstractModel
         $getter = sprintf('get%s', ucfirst($property));
 
         if (method_exists($this, $getter)) {
-            return true;
+            return $this->{$getter}() !== null;
         }
 
-        return isset($this->data[$property]);
+        return isset($this->data[$property]) && $this->data[$property] !== null;
     }
 
     /**

--- a/tests/Model/AbstractModelTest.php
+++ b/tests/Model/AbstractModelTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Picqer\BolRetailer\Tests\Model;
+
+use Picqer\BolRetailer\Model\AbstractModel;
+
+class AbstractModelTest extends \PHPUnit\Framework\TestCase
+{
+    private $model;
+
+    public function setup(): void
+    {
+        $this->model = new FixtureModel([
+            'foo' => 'lorem',
+            'bar' => 'ipsum',
+            'baz' => 'dolor',
+            'qux' => null,
+            'qax' => '',
+        ]);
+    }
+
+    public function testChecksIfPropertyIsSet()
+    {
+        $this->assertTrue(isset($this->model->foo));
+        $this->assertTrue(isset($this->model->bar));
+        $this->assertTrue(isset($this->model->baz));
+        $this->assertFalse(isset($this->model->qux));
+        $this->assertTrue(isset($this->model->qax));
+    }
+
+    public function testChecksIfPropertyIsEmpty()
+    {
+        $this->assertFalse(empty($this->model->foo));
+        $this->assertFalse(empty($this->model->bar));
+        $this->assertFalse(empty($this->model->baz));
+        $this->assertTrue(empty($this->model->qux));
+        $this->assertTrue(empty($this->model->qax));
+    }
+}
+
+class FixtureModel extends AbstractModel
+{
+    public function getFoo(): ?string
+    {
+        return isset($this->data['foo']) ? strtoupper($this->data['foo']) : null;
+    }
+}


### PR DESCRIPTION
The `__isset` method is required to add support for, for example, `isset($order->addressDetails)` and `empty($orderItem->latestDeliveryDate)`.