### PR TITLE
Fix authentication exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -56,7 +56,7 @@ class Client
         }
 
         $token = json_decode((string)$response->getBody(), true);
-        if (! is_array($token) || ! isset($token['expires_in'])) {
+        if (! is_array($token) || empty($token['access_token']) || empty($token['expires_in'])) {
             throw new AuthenticationException('Could not retrieve valid token from Bol API');
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -45,17 +45,21 @@ class Client
                 'headers' => $headers,
                 'form_params' => $params
             ]);
-        } catch (GuzzleException $e) {
-            if ($e instanceof RequestException) {
-                $response = json_decode((string)$e->getResponse()->getBody(), true);
+        } catch (GuzzleException $exception) {
+            if ($exception instanceof RequestException) {
+                $response = json_decode((string)$exception->getResponse()->getBody(), true);
 
-                throw new AuthenticationException($response['error_description'] ?? null, $e->getCode(), $e);
+                throw new AuthenticationException($response['error_description'] ?? null);
             }
 
-            throw new AuthenticationException(null, $e->getCode(), $e);
+            throw new AuthenticationException($exception->getMessage());
         }
 
         $token = json_decode((string)$response->getBody(), true);
+        if (! is_array($token) || ! isset($token['expires_in'])) {
+            throw new AuthenticationException('Could not retrieve valid token from Bol API');
+        }
+
         $token['expires_at'] = time() + $token['expires_in'] ?? 0;
 
         static::$token = $token;

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -8,7 +8,7 @@ class AuthenticationException extends \Exception
 {
     public function __construct(?string $message = null, int $code = 0, Exception $previous = null)
     {
-        $message = $message ?: 'An unknown error occured during the authentication with Bol.com';
+        $message = $message ?: 'An unknown error occurred during the authentication with Bol.com';
 
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
With invalid credentials, the client would fail to build an `AuthenticationException` and give a Guzzle exception.

Also the response was not checked, now we check the contents of the token before we declare victory.