### PR TITLE
Add support for PHP 8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: Main pipeline
+on: [push, pull_request]
+jobs:
+    Tests:
+        runs-on: ubuntu-18.04
+        strategy:
+            matrix:
+                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Set up PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+            - name: Run tests
+              run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 phpcs.xml
 phpunit.xml
 .idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         }
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.1|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.11.12",
-        "phpunit/phpunit": ">=7.0",
+        "phpstan/phpstan": "^0.12",
+        "phpunit/phpunit": "^7|^8",
         "squizlabs/php_codesniffer": "^3.0",
         "vimeo/psalm": "^3.5"
     },


### PR DESCRIPTION
This PR adds support for PHP 8.

To ensure everything works as expected I also added a Github Action to run the tests on PHP 7.1, 7.2, 7.3, 7.4 and 8.0.

I did change PHPUnit's version to 7.x and 8.x, this is because PHPUnit 9 has deprecation warnings on the `prophesize` method. Whilst this can be fixed by adding [https://github.com/phpspec/prophecy-phpunit](phpspec/prophecy-phpunit), this would require a major bump since that package does not support 7.1 and 7.2