### PR TITLE
Accept lower case token type and scopes when validating access tokens (version 4)

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -147,13 +147,13 @@ class BaseClient
             throw new ResponseException('Missing expires_in');
         }
 
-        if ($token['token_type'] != 'Bearer') {
+        if (strtolower($token['token_type']) !== 'bearer') {
             throw new ResponseException(
                 sprintf('Unexpected token_type \'%s\', expected \'Bearer\'', $token['token_type'])
             );
         }
 
-        if ($token['scope'] != 'RETAILER') {
+        if (strtolower($token['scope']) !== 'retailer') {
             throw new ResponseException(
                 sprintf('Unexpected token_type \'%s\', expected \'RETAILER\'', $token['scope'])
             );

--- a/tests/Fixtures/http/200-token-lowercase-scope
+++ b/tests/Fixtures/http/200-token-lowercase-scope
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "access_token": "sometoken",
+  "token_type": "Bearer",
+  "expires_in": 299,
+  "scope": "retailer"
+}

--- a/tests/Fixtures/http/200-token-lowercase-type
+++ b/tests/Fixtures/http/200-token-lowercase-type
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "access_token": "sometoken",
+  "token_type": "bearer",
+  "expires_in": 299,
+  "scope": "RETAILER"
+}


### PR DESCRIPTION
The client currently expects the scope and token type to have a very specific casing. This is not required for the API. For example, both `retailer` and `RETAILER` are allowed scopes. This PR fixes this issue for version 4 of the client.