### PR TITLE
Accept lower case token type and scopes when validating access tokens (version 5)

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -147,13 +147,13 @@ class BaseClient
             throw new ResponseException('Missing expires_in');
         }
 
-        if ($token['token_type'] != 'Bearer') {
+        if (strtolower($token['token_type']) !== 'bearer') {
             throw new ResponseException(
                 sprintf('Unexpected token_type \'%s\', expected \'Bearer\'', $token['token_type'])
             );
         }
 
-        if ($token['scope'] != 'RETAILER') {
+        if (strtolower($token['scope']) !== 'retailer') {
             throw new ResponseException(
                 sprintf('Unexpected token_type \'%s\', expected \'RETAILER\'', $token['scope'])
             );

--- a/tests/BaseClientTest.php
+++ b/tests/BaseClientTest.php
@@ -17,6 +17,7 @@ use Picqer\BolRetailerV5\Model\AbstractModel;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
 
 class BaseClientTest extends TestCase
 {
@@ -54,9 +55,9 @@ class BaseClientTest extends TestCase
         $this->assertFalse($this->client->isAuthenticated());
     }
 
-    protected function authenticate()
+    protected function authenticate(?ResponseInterface $response = null)
     {
-        $response = Message::parseResponse(file_get_contents(__DIR__ . '/Fixtures/http/200-token'));
+        $response = $response ?? Message::parseResponse(file_get_contents(__DIR__ . '/Fixtures/http/200-token'));
 
         $credentials = base64_encode('secret_id' . ':' . 'somesupersecretvaluethatshouldnotbeshared');
         $this->httpProphecy->request('POST', 'https://login.bol.com/token', [
@@ -75,6 +76,20 @@ class BaseClientTest extends TestCase
     public function testClientIsAuthenticatedAfterSuccessfulAuthentication()
     {
         $this->authenticate();
+
+        $this->assertTrue($this->client->isAuthenticated());
+    }
+
+    public function testClientAcceptsLowercaseScopeInAccessToken()
+    {
+        $this->authenticate(Message::parseResponse(file_get_contents(__DIR__ . '/Fixtures/http/200-token-lowercase-scope')));
+
+        $this->assertTrue($this->client->isAuthenticated());
+    }
+
+    public function testClientAcceptsLowercaseTokenTypeInAccessToken()
+    {
+        $this->authenticate(Message::parseResponse(file_get_contents(__DIR__ . '/Fixtures/http/200-token-lowercase-type')));
 
         $this->assertTrue($this->client->isAuthenticated());
     }

--- a/tests/Fixtures/http/200-token-lowercase-scope
+++ b/tests/Fixtures/http/200-token-lowercase-scope
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "access_token": "sometoken",
+  "token_type": "Bearer",
+  "expires_in": 299,
+  "scope": "retailer"
+}

--- a/tests/Fixtures/http/200-token-lowercase-type
+++ b/tests/Fixtures/http/200-token-lowercase-type
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "access_token": "sometoken",
+  "token_type": "bearer",
+  "expires_in": 299,
+  "scope": "RETAILER"
+}


### PR DESCRIPTION
The client currently expects the scope and token type to have a very specific casing. This is not required for the API. For example, both `retailer` and `RETAILER` are allowed scopes. This PR fixes this issue for version 4 of the client.