### PR TITLE
Name parameter for insights/performance/indicator

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -164,7 +164,7 @@ class Client extends BaseClient
         $url = "insights/performance/indicator";
         $options = [
             'query' => [
-                'name' => $name,
+                'name' => implode(',', $name),
                 'year' => $year,
                 'week' => $week,
             ],


### PR DESCRIPTION
Fix  to make getPerformanceIndicator() work.
The `name` parameter cannot be an array, but must be a comma separated string.