### PR TITLE
Accept default request options when creating a new client

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -37,10 +37,12 @@ class BaseClient
 
     /**
      * BaseClient constructor.
+     *
+     * @param array $options The options to use for the default HTTP client.
      */
-    public function __construct()
+    public function __construct(array $options = [])
     {
-        $this->setHttp(new HttpClient());
+        $this->setHttp(new HttpClient($options));
     }
 
     /**

--- a/tests/BaseClientTest.php
+++ b/tests/BaseClientTest.php
@@ -50,6 +50,16 @@ class BaseClientTest extends TestCase
         $this->modelClass = get_class($stub);
     }
 
+    public function testClientHasDefaultHttpRequestOptions()
+    {
+        $client = new BaseClient([
+            'timeout' => 10,
+        ]);
+
+        $http = $client->getHttp();
+        $this->assertEquals(10, $http->getConfig('timeout'));
+    }
+
     public function testClientIsInitiallyNotAuthenticated()
     {
         $this->assertFalse($this->client->isAuthenticated());


### PR DESCRIPTION
This PR adds support for configuring request options for the default HTTP client when creating a `BaseClient` or `Client` instance:

```php
// Configure the cURL handler to use a request timeout of 10s
$client = new Client([
    'timeout' => 10.0,
]);
```