### PR TITLE
Fix content type for requests that contain a body

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -396,7 +396,7 @@ class BaseClient
 
         // encode the body if a model is supplied for it
         if (isset($options['body']) && $options['body'] instanceof AbstractModel) {
-            $httpOptions['headers']['Content-Type'] = static::API_CONTENT_TYPE_JSON;
+            $httpOptions['headers']['Content-Type'] = $options['produces'] ?? static::API_CONTENT_TYPE_JSON;
             $httpOptions['body'] = json_encode($options['body']->toArray(true));
         }
 


### PR DESCRIPTION
When you use `postOfferExport()` you'll end up with an error that states 
```
Picqer\BolRetailerV10\Exception\ResponseException
The supplied content-type media type is not supported.
```

This is due to an issue where the Client uses the wrong `Content-Type` header. This API should contain the header 
`application/vnd.retailer.v9+json` but the current code ignores the provided `produces` option and defaults to `application/vnd.retailer.v10+json`, causing issues with some endpoints.

This change addresses this issue.