### PR TITLE
Fix: Use Content-Type from specs to prevent 'The supplied content-type media type is not supported.'

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -21,7 +21,8 @@ class BaseClient
 {
     protected const API_TOKEN_URI = 'https://login.bol.com/token';
     protected const API_ENDPOINT = 'https://api.bol.com/';
-    protected const API_CONTENT_TYPE_JSON = 'application/vnd.retailer.v10+json';
+    protected const API_CONTENT_TYPE_FALLBACK = 'application/vnd.retailer.v10+json';
+    protected const API_ACCEPT_FALLBACK = 'application/vnd.retailer.v10+json';
 
     /**
      * @var bool Whether request will be sent to the demo endpoint.
@@ -390,13 +391,13 @@ class BaseClient
 
         $httpOptions = [];
         $httpOptions['headers'] = [
-            'Accept' => $options['produces'] ?? static::API_CONTENT_TYPE_JSON,
+            'Accept' => $options['produces'] ?? static::API_ACCEPT_FALLBACK,
             'Authorization' => sprintf('Bearer %s', $this->accessToken->getToken()),
         ];
 
         // encode the body if a model is supplied for it
         if (isset($options['body']) && $options['body'] instanceof AbstractModel) {
-            $httpOptions['headers']['Content-Type'] = static::API_CONTENT_TYPE_JSON;
+            $httpOptions['headers']['Content-Type'] = $options['consumes'] ?? static::API_CONTENT_TYPE_FALLBACK;
             $httpOptions['body'] = json_encode($options['body']->toArray(true));
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\BulkCommissionRequest::constructFromArray(['commissionQueries' => $commissionQueries]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '200' => Model\BulkCommissionResponse::class,
@@ -105,6 +106,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\ChunkRecommendationsRequest::constructFromArray(['productContents' => $productContents]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '200' => Model\ChunkRecommendationsResponse::class,
@@ -129,6 +131,7 @@ class Client extends BaseClient
         $options = [
             'body' => $createProductContentSingleRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -430,6 +433,7 @@ class Client extends BaseClient
         $options = [
             'body' => $createOfferRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -454,6 +458,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\CreateOfferExportRequest::constructFromArray(['format' => $format]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -502,6 +507,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\CreateUnpublishedOfferReportRequest::constructFromArray(['format' => $format]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -575,6 +581,7 @@ class Client extends BaseClient
         $options = [
             'body' => $updateOfferRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -623,6 +630,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\UpdateOfferPriceRequest::constructFromArray(['pricing' => $pricing]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -648,6 +656,7 @@ class Client extends BaseClient
         $options = [
             'body' => $updateOfferStockRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -711,6 +720,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\ContainerForTheOrderItemsThatHaveToBeCancelled::constructFromArray(['orderItems' => $orderItems]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -738,6 +748,7 @@ class Client extends BaseClient
         $options = [
             'body' => $shipmentRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1103,6 +1114,7 @@ class Client extends BaseClient
         $options = [
             'body' => $createReplenishmentRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1149,6 +1161,7 @@ class Client extends BaseClient
         $options = [
             'body' => $pickupTimeSlotsRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '200' => Model\PickupTimeSlotsResponse::class,
@@ -1173,6 +1186,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\RequestProductDestinationsRequest::constructFromArray(['eans' => $eans]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1222,6 +1236,7 @@ class Client extends BaseClient
         $options = [
             'body' => $productLabelsRequest,
             'produces' => 'application/vnd.retailer.v9+pdf',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '200' => 'string',
@@ -1272,6 +1287,7 @@ class Client extends BaseClient
         $options = [
             'body' => $updateReplenishmentRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1455,6 +1471,7 @@ class Client extends BaseClient
         $options = [
             'body' => $returnRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1536,6 +1553,7 @@ class Client extends BaseClient
         $options = [
             'body' => $shippingLabelRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1561,6 +1579,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\DeliveryOptionsRequest::constructFromArray(['orderItems' => $orderItems]),
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '200' => Model\DeliveryOptionsResponse::class,
@@ -1636,6 +1655,7 @@ class Client extends BaseClient
         $options = [
             'body' => $createSubscriptionRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1682,6 +1702,7 @@ class Client extends BaseClient
         $url = "retailer/subscriptions/test/${subscriptionId}";
         $options = [
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1732,6 +1753,7 @@ class Client extends BaseClient
         $options = [
             'body' => $updateSubscriptionRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1755,6 +1777,7 @@ class Client extends BaseClient
         $url = "retailer/subscriptions/${subscriptionId}";
         $options = [
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1781,6 +1804,7 @@ class Client extends BaseClient
         $options = [
             'body' => $changeTransportRequest,
             'produces' => 'application/vnd.retailer.v9+json',
+            'consumes' => 'application/vnd.retailer.v9+json',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1868,6 +1892,7 @@ class Client extends BaseClient
                 ],
             ],
             'produces' => 'application/vnd.retailer.v10+json',
+            'consumes' => 'multipart/form-data',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,
@@ -1932,6 +1957,7 @@ class Client extends BaseClient
         $options = [
             'body' => Model\BulkProcessStatusRequest::constructFromArray(['processStatusQueries' => $processStatusQueries]),
             'produces' => 'application/vnd.retailer.v10+json',
+            'consumes' => 'application/vnd.retailer.v10+json',
         ];
         $responseTypes = [
             '200' => Model\ProcessStatusResponse::class,

--- a/src/OpenApi/ClientGenerator.php
+++ b/src/OpenApi/ClientGenerator.php
@@ -110,6 +110,11 @@ class ClientGenerator
         $this->addBodyParam($arguments, $code);
         $this->addFormData($arguments, $code);
         $code[] = sprintf('            \'produces\' => \'%s\',', $methodDefinition['produces'][0]);
+
+        if ($methodDefinition['consumes'] ?? false) {
+            $code[] = sprintf('            \'consumes\' => \'%s\',', $methodDefinition['consumes'][0]);
+        }
+
         $code[] = '        ];';
         $options = '$options';
 

--- a/tests/BaseClientTest.php
+++ b/tests/BaseClientTest.php
@@ -600,6 +600,35 @@ class BaseClientTest extends TestCase
         $this->assertEquals('application/vnd.retailer.v10+pdf', $actualOptions['headers']['Accept']);
     }
 
+    public function testRequestAddsConsumesAsContentTypeHeader()
+    {
+        $this->authenticateByClientCredentials();
+
+        $model = new $this->modelClass();
+        $model->foo = 'bar';
+
+        $actualOptions = null;
+        $response = Message::parseResponse(file_get_contents(__DIR__ . '/Fixtures/http/200-string'));
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->willReturnCallback(function ($method, $uri, $options) use ($response, &$actualOptions) {
+                $actualOptions = $options;
+                return $response;
+            });
+
+        $this->client->request('POST', 'foobar', [
+            'body' => $model,
+            'consumes' => 'application/vnd.retailer.vxx+json'
+        ], [
+            '200' => 'string'
+        ]);
+
+        $this->assertArrayHasKey('headers', $actualOptions);
+        $this->assertArrayHasKey('Accept', $actualOptions['headers']);
+        $this->assertEquals('application/vnd.retailer.vxx+json', $actualOptions['headers']['Content-Type']);
+    }
+
     public function testRequestJsonEncodesBodyModelIntoBody()
     {
         $this->authenticateByClientCredentials();


### PR DESCRIPTION
In #33 @lenvanessen found a bug regarding invalid `Content-Type` header: `application/vnd.retailer.v10+json` is used while it should be using `application/vnd.retailer.v9+json`. This results in the error response 'The supplied content-type media type is not supported.'

In `BaseClient` a constant is used as `Content-Type`, which means all methods use the same value for this header. With the introduction of v10 of the API this bug was introduced: v10 is only partially defined in the OpenAPI specs, so it is merged with the v9 specs. Some methods now require v9 of the `Content-Type` header while others require v10.

The OpenAPI specs specifies both `produces` and `consumes`. The first should be (and is) sent as `Accept` header, the latter as `Content-Type`. So in this PR the use of the constant is replaced with the `consumes` value from the specs.