### PR TITLE
Upload invoice bugfix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1585,7 +1585,7 @@ class Client extends BaseClient
      * @throws Exception\RateLimitException when the throttling limit has been reached for the API user.
      * @throws Exception\Exception when something unexpected went wrong.
      */
-    public function uploadInvoice(string $shipmentId, string $invoice): ?Model\ProcessStatus
+    public function uploadInvoice(string $invoice, string $shipmentId): ?Model\ProcessStatus
     {
         $url = "retailer/shipments/invoices/{$shipmentId}";
         $options = [

--- a/src/Client.php
+++ b/src/Client.php
@@ -1577,6 +1577,7 @@ class Client extends BaseClient
     /**
      * Uploads an invoice associated with shipment id.
      * @param string $shipmentId The id of the shipment associated with the invoice.
+     * @param string $invoice
      * @return Model\ProcessStatus|null
      * @throws Exception\ConnectException when an error occurred in the HTTP connection.
      * @throws Exception\ResponseException when an unexpected response was received.
@@ -1584,12 +1585,18 @@ class Client extends BaseClient
      * @throws Exception\RateLimitException when the throttling limit has been reached for the API user.
      * @throws Exception\Exception when something unexpected went wrong.
      */
-    public function uploadInvoice(string $shipmentId): ?Model\ProcessStatus
+    public function uploadInvoice(string $shipmentId, string $invoice): ?Model\ProcessStatus
     {
         $url = "retailer/shipments/invoices/{$shipmentId}";
         $options = [
+            'multipart' => [
+                [
+                    'name' => 'invoice',
+                    'contents' => \GuzzleHttp\Psr7\Utils::tryFopen($invoice, 'r'),
+                ],
+            ],
             'produces' => 'application/vnd.retailer.v10+json',
-            'consumes' => 'application/json',
+            'consumes' => 'multipart/form-data',
         ];
         $responseTypes = [
             '202' => Model\ProcessStatus::class,


### PR DESCRIPTION
The `uploadInvoice` function is broken after the last update. There was no way to actually upload the invoice, since you couldn't pass the invoice to the function. The `uploadInvoice` function was modified in #42, and broken since then.

I restored the code to the state of how it was in the previous release. That has always worked for us.

If there are any comments, please let me know!