### PR TITLE
fixed Picqer\BolRetailerV10\BaseClient::Picqer\BolRetailerV10\{closur…

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -19,6 +19,7 @@ use Picqer\BolRetailerV10\Exception\ResponseException;
 use Picqer\BolRetailerV10\Exception\UnauthorizedException;
 use Picqer\BolRetailerV10\Model\Authentication\TokenResponse;
 use Picqer\BolRetailerV10\Model\Authentication\TokenRequest;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -608,7 +609,7 @@ class BaseClient
             $retries,
             RequestInterface $request,
             ?ResponseInterface $response = null,
-            RequestException|ClientException|null $exception = null
+            ?ClientExceptionInterface $exception = null
         ) {
             return $this->respectRateLimits
                 && $response

--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -4,6 +4,7 @@ namespace Picqer\BolRetailerV10;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
 use GuzzleHttp\Exception\RequestException;
@@ -607,7 +608,7 @@ class BaseClient
             $retries,
             RequestInterface $request,
             ?ResponseInterface $response = null,
-            ?RequestException $exception = null
+            RequestException|ClientException|null $exception = null
         ) {
             return $this->respectRateLimits
                 && $response


### PR DESCRIPTION
fixed Picqer\BolRetailerV10\BaseClient::Picqer\BolRetailerV10\{closure}(): Argument #4 ($exception) must be of type ?GuzzleHttp\Exception\RequestException, GuzzleHttp\Exception\ConnectException given, called in /application/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php on line 100