### PR TITLE
Fix Deprecated Warning: Optional parameter $response before required …

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -617,13 +617,14 @@ class BaseClient
     }
 
     private function retryDelay()
-    {
-        return function (
-            $retries,
-            ?ResponseInterface $response = null,
-            RequestInterface $request
-        ) {
-            return (int)$response->getHeaderLine('Retry-After') * 1000;
-        };
-    }
+	{
+    	return function (
+        	$retries,
+        	RequestInterface $request,
+        	?ResponseInterface $response = null
+    	) {
+        	return (int)$response->getHeaderLine('Retry-After') * 1000;
+    	};
+	}
+
 }


### PR DESCRIPTION
…parameter $request

This change addresses the deprecated warning in PHP 8 regarding the optional parameter $response being declared before the required parameter $request in the retryDelay method of the BaseClient.php file.

In newer versions of PHP, optional parameters must come after required parameters. This update ensures compatibility with these newer PHP versions.