### PR TITLE
Fix getCommissionRates by adding response type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -84,6 +84,7 @@ class Client extends BaseClient
             'consumes' => 'application/vnd.retailer.v10+json',
         ];
         $responseTypes = [
+            '207' => Model\BulkCommissionRatesMultiStatusResponse::class
         ];
 
         return $this->request('POST', $url, $options, $responseTypes);


### PR DESCRIPTION
There was no response type for the getCommissionRates which makes it impossible for the library to decode the response into the corresponding model. Added code 207 as documented by Bol.