### PR TITLE
Supply the request parameters in the body

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -274,7 +274,7 @@ class BaseClient
                 'Accept' => 'application/json',
                 'Authorization' => sprintf('Basic %s', $credentials)
             ],
-            'query' => $token->toArray()
+            'body' => $token->toArray()
         ]);
 
         $responseTypes = [

--- a/tests/BaseClientTest.php
+++ b/tests/BaseClientTest.php
@@ -234,7 +234,7 @@ class BaseClientTest extends TestCase
                 'Accept' => 'application/json',
                 'Authorization' => 'Basic ' . $credentials
             ],
-            'query' => [
+            'body' => [
                 'grant_type' => 'client_credentials'
             ]
         ])->willReturn($response);
@@ -375,7 +375,7 @@ class BaseClientTest extends TestCase
                 'Accept' => 'application/json',
                 'Authorization' => 'Basic ' . $credentials
             ],
-            'query' => [
+            'body' => [
                 'grant_type' => 'authorization_code',
                 'code' => '123456',
                 'redirect_uri' => 'http://someserver.xxx/redirect',
@@ -430,7 +430,7 @@ class BaseClientTest extends TestCase
                 'Accept' => 'application/json',
                 'Authorization' => 'Basic ' . $credentials
             ],
-            'query' => [
+            'body' => [
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $this->validRefreshToken->getToken()
             ]

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
                 'Accept' => 'application/json',
                 'Authorization' => 'Basic ' . $credentials
             ],
-            'query' => [
+            'body' => [
                 'grant_type' => 'client_credentials'
             ]
         ])->willReturn($response);


### PR DESCRIPTION
As noted in the [Retailer API documentation](https://api.bol.com/retailer/public/Retailer-API/intermediary-authorization.html#_code_flow_diagram), the request parameters required to obtain a token must be included in the request body rather than in the URL parameters. While bol.com has previously accepted parameters in the URL, this approach will no longer work starting November 18th this year.

To ensure compatibility with this upcoming change in the Bol API, the parameters are now included in the request body instead of the URL.