### PR TITLE
Refresh token as body instead of querystring

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -272,9 +272,10 @@ class BaseClient
         $response = $this->rawRequest('POST', static::API_TOKEN_URI, [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => sprintf('Basic %s', $credentials)
+                'Authorization' => sprintf('Basic %s', $credentials),
+                'Content-Type' => 'application/x-www-form-urlencoded',
             ],
-            'query' => $token->toArray()
+            'body' => http_build_query($token->toArray())
         ]);
 
         $responseTypes = [

--- a/tests/BaseClientTest.php
+++ b/tests/BaseClientTest.php
@@ -232,11 +232,10 @@ class BaseClientTest extends TestCase
         $httpClientMock->method('request')->with('POST', 'https://login.bol.com/token', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic ' . $credentials
+                'Authorization' => 'Basic ' . $credentials,
+                'Content-Type' => 'application/x-www-form-urlencoded'
             ],
-            'query' => [
-                'grant_type' => 'client_credentials'
-            ]
+            'body' => 'grant_type=client_credentials'
         ])->willReturn($response);
 
         // use the HttpClient mock created in this method for authentication, put the original one back afterwards
@@ -373,13 +372,10 @@ class BaseClientTest extends TestCase
         $httpClientMock->method('request')->with('POST', 'https://login.bol.com/token', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic ' . $credentials
+                'Authorization' => 'Basic ' . $credentials,
+                'Content-Type' => 'application/x-www-form-urlencoded'
             ],
-            'query' => [
-                'grant_type' => 'authorization_code',
-                'code' => '123456',
-                'redirect_uri' => 'http://someserver.xxx/redirect',
-            ]
+            'body' => 'grant_type=authorization_code&code=123456&redirect_uri=http%3A%2F%2Fsomeserver.xxx%2Fredirect'
         ])->willReturn($response);
 
         // use the HttpClient mock created in this method for authentication, put the original one back afterwards
@@ -428,12 +424,10 @@ class BaseClientTest extends TestCase
         $httpClientMock->method('request')->with('POST', 'https://login.bol.com/token', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic ' . $credentials
+                'Authorization' => 'Basic ' . $credentials,
+                'Content-Type' => 'application/x-www-form-urlencoded'
             ],
-            'query' => [
-                'grant_type' => 'refresh_token',
-                'refresh_token' => $this->validRefreshToken->getToken()
-            ]
+            'body' => 'grant_type=refresh_token&refresh_token=' . $this->validRefreshToken->getToken()
         ])->willReturn($response);
 
         // use the HttpClient mock created in this method for authentication, put the original one back afterwards

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -41,11 +41,10 @@ class ClientTest extends TestCase
         $httpClientMock->method('request')->with('POST', 'https://login.bol.com/token', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic ' . $credentials
+                'Authorization' => 'Basic ' . $credentials,
+                'Content-Type' => 'application/x-www-form-urlencoded'
             ],
-            'query' => [
-                'grant_type' => 'client_credentials'
-            ]
+            'body' => 'grant_type=client_credentials'
         ])->willReturn($response);
 
         // use the HttpClient mock created in this method for authentication, put the original one back afterwards


### PR DESCRIPTION
A tested version of #54, where we should use the body instead of querystrings to get a new token from a refresh token.