### PR TITLE
Voeg de mogelijkheid toe om (alleen) de headers van een response te verkrijgen.

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -342,7 +342,7 @@ class BaseClient
      * @param string $url Url
      * @param array $options Request options to apply
      * @param array $responseTypes Expected response type per HTTP status code
-     * @return AbstractModel|string|null Model or array representing response
+     * @return AbstractModel|array|string|null Model or array representing response
      * @throws ConnectException when an error occurred in the HTTP connection.
      * @throws UnauthorizedException when the request was unauthorized.
      * @throws ResponseException when no suitable responseType could be applied.
@@ -355,6 +355,7 @@ class BaseClient
         $this->validateToken();
 
         try {
+            /** @var ResponseInterface $response */
             $response = $this->prepareAndExecuteRequest($method, $url, $options);
         } catch (UnauthorizedException $e) {
             if (! $e->accessTokenExpired()) {
@@ -373,6 +374,10 @@ class BaseClient
             } else {
                 throw $e;
             }
+        }
+
+        if ($method === 'HEAD' && $response->getStatusCode() === 200) {
+            return $response->getHeaders();
         }
 
         return $this->decodeResponse($response, $responseTypes, $url);

--- a/src/Client.php
+++ b/src/Client.php
@@ -1801,6 +1801,31 @@ class Client extends BaseClient
     }
 
     /**
+     * Retrieves the headers of a shipping label by shipping label id. Shipping label metadata, for example the X-Track-And-Trace-Code, are added as headers
+     * in the response.
+     *
+     * @param string $shippingLabelId
+     * @return string|null
+     * @throws Exception\ConnectException
+     * @throws Exception\Exception
+     * @throws Exception\RateLimitException
+     * @throws Exception\ResponseException
+     * @throws Exception\UnauthorizedException
+     */
+    public function getShippingLabelHeaders(string $shippingLabelId): ?array
+    {
+        $url = "retailer/shipping-labels/{$shippingLabelId}";
+        $options = [
+            'produces' => 'application/vnd.retailer.v10+pdf',
+        ];
+        $responseTypes = [
+            '404' => 'null',
+        ];
+
+        return $this->request('HEAD', $url, $options, $responseTypes);
+    }
+
+    /**
      * Retrieves all event notification subscriptions for a given retailer. Each subscription may have different types
      * of events and a destination, which could either be a URL (for WEBHOOK) or a topic name (for GCP_PUBSUB).
      * @return Model\SubscriptionResponse[]


### PR DESCRIPTION
Voor het verkrijgen van de track and trace code van een verzend label moet je een header van het [get shipment label endpoint](https://api.bol.com/retailer/public/redoc/v10/retailer.html#tag/Shipping-Labels/operation/get-shipping-label) uitlezen.

De client is zo gebouwd dat alleen de response body decoded en returned kan worden.