### PR TITLE
Handle client exception case with complete error message

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -61,6 +61,9 @@ class BaseClient
             $this->retryDelay()
         ));
 
+        $handlerStack->remove('http_errors');
+        $handlerStack->unshift(Middleware::httpErrors(new BodySummarizer(1500)), 'http_errors');
+
         $this->setHttp(new HttpClient([
             'handler' => $handlerStack,
         ]));
@@ -541,6 +544,12 @@ class BaseClient
                 $connectException->getMessage(),
                 $connectException->getCode(),
                 $connectException
+            );
+        } catch (ClientException $clientException) {
+            throw new RequestException(
+                $clientException->getMessage(),
+                $clientException->getCode(),
+                $clientException
             );
         } catch (BadResponseException $badResponseException) {
             $response = $badResponseException->getResponse();

--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -2,6 +2,7 @@
 
 namespace Picqer\BolRetailerV10;
 
+use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;


### PR DESCRIPTION
I was doing asset uploads to Bol.com and all I received was the message `Bad Request`. Not very informative :)

So I did some digging and at some point received the first part of the message but the rest was truncated due to the large message it is.

After some more digging I found out that we can enlarge the size of the response message, that is my first change in the constructor.

As I was still getting the `Bad Request` message I dug further and found that Guzzle throws a `ClientException` which is not caught and as a result I just get the `Bad Request`. So this is the second change in this file where I catch the  `ClientException` and then throw it as a `RequestException` that contains the full message from the `ClientException`.

The result is that I receive the full message in my code and can deal with it accordingly. The source of my error was uploading assets without labels. That is what the real error message is telling me :)